### PR TITLE
Pm 3355 several table on same page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Changelog
   management of `apply` button title, that will be `Apply` by default but that
   may be changed to fit the current batch action.
   [gbastien]
+- Added `DeleteBatchActionForm` a delete elements batch action.
+  [gbastien]
 
 1.6 (2020-12-21)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,15 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Added possibility to define the name of the `CheckBoxColumn`
-  (`select_item` by default), necessary when displaying several tables
-  on the same page.
+- Adapted code to be able to display several tables on same page
+  (and so several batchactions viewlets):
+
+  - Added possibility to define the name of the `CheckBoxColumn`
+    (still `select_item` by default);
+  - Introduce idea of section for the viewlet and the batch actions so it is
+    possible to display different actions on different viewlets or different
+    views of same context.
+
   [gbastien]
 
 1.6 (2020-12-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,10 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Added possibility to define the name of the `CheckBoxColumn`
+  (`select_item` by default), necessary when displaying several tables
+  on the same page.
+  [gbastien]
 
 1.6 (2020-12-21)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,13 @@ Changelog
     views of same context.
 
   [gbastien]
+- Added method `BaseBatchActionForm._final_update` called when every other
+  `update` methods have been called.
+  [gbastien]
+- Added `BaseBatchActionForm.apply_button_title` attribute to formalize
+  management of `apply` button title, that will be `Apply` by default but that
+  may be changed to fit the current batch action.
+  [gbastien]
 
 1.6 (2020-12-21)
 ----------------

--- a/src/collective/eeafaceted/batchactions/__init__.py
+++ b/src/collective/eeafaceted/batchactions/__init__.py
@@ -3,6 +3,7 @@
 
 from zope.i18nmessageid import MessageFactory
 
+
 _ = MessageFactory('collective.eeafaceted.batchactions')
 
 

--- a/src/collective/eeafaceted/batchactions/browser/configure.zcml
+++ b/src/collective/eeafaceted/batchactions/browser/configure.zcml
@@ -22,4 +22,10 @@
         class=".views.TransitionBatchActionForm"
         permission="zope2.View" />
 
+    <!--browser:page
+        for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
+        name="delete-batch-action"
+        class=".views.DeleteBatchActionForm"
+        permission="zope2.View" /-->
+
 </configure>

--- a/src/collective/eeafaceted/batchactions/browser/static/batch_actions.js
+++ b/src/collective/eeafaceted/batchactions/browser/static/batch_actions.js
@@ -8,7 +8,8 @@ collective_batch_actions.init_button = function () {
 
   $('.batch-action-but').click(function (e) {
     e.preventDefault();
-    var uids = selectedCheckBoxes('select_item');
+    select_item_name = $(this).parents("div#batch-actions").data().select_item_name;
+    var uids = selectedCheckBoxes(select_item_name);
     if (!uids.length) { alert(no_selected_items); return false;}
     var referer = document.location.href.replace('#','!').replace(/&/g,'@');
     var ba_form = $(this).parent()[0];

--- a/src/collective/eeafaceted/batchactions/browser/static/batch_actions.js
+++ b/src/collective/eeafaceted/batchactions/browser/static/batch_actions.js
@@ -28,7 +28,7 @@ collective_batch_actions.init_button = function () {
     uids_input.val(uids);
     ba_form.action = document.batch_actions[form_id] + '?referer=' + referer;
     if ($(ba_form).hasClass('do-overlay')) {
-      collective_batch_actions.initializeOverlays('#'+form_id);
+      collective_batch_actions.initializeOverlays(ba_form);
     }
     else {
       ba_form.submit();
@@ -37,9 +37,9 @@ collective_batch_actions.init_button = function () {
   });
 };
 
-collective_batch_actions.initializeOverlays = function (form_id) {
+collective_batch_actions.initializeOverlays = function (ba_form) {
     // Add batch actions popup
-    $(form_id).prepOverlay({
+    $(ba_form).prepOverlay({
         api: true,
         subtype: 'ajax',
         closeselector: '[name="form.buttons.cancel"]',

--- a/src/collective/eeafaceted/batchactions/browser/templates/batch_actions_viewlet.pt
+++ b/src/collective/eeafaceted/batchactions/browser/templates/batch_actions_viewlet.pt
@@ -1,5 +1,6 @@
 <div i18n:domain="collective.eeafaceted.batchactions"
      id="batch-actions"
+     tal:attributes="data-select_item_name python: view.select_item_name"
      tal:condition="view/available">
   <form method="POST"
         tal:repeat="batch_action view/get_batch_actions"
@@ -10,7 +11,7 @@
     <input tal:define="base_css_classes string:button batch-action-but"
            tal:attributes="value string:${batch_action/name}-but;
                            id string:${batch_action/name}-but;
-                           class python: not batch_action['button_with_icon'] and base_css_classes or base_css_classes + ' batch-action-icon-but'"
+                           class python: not batch_action['button_with_icon'] and base_css_classes or base_css_classes + ' batch-action-icon-but';"
            type="submit"
            i18n:attributes="value"/>
   </form>

--- a/src/collective/eeafaceted/batchactions/browser/viewlets.py
+++ b/src/collective/eeafaceted/batchactions/browser/viewlets.py
@@ -18,6 +18,12 @@ class BatchActionsViewlet(ViewletBase):
         """Global availability of the viewlet."""
         return True
 
+    @property
+    def select_item_name(self):
+        """The name of the chekbox column, useful when displaying
+           several table on same page."""
+        return "select_item"
+
     def _get_marker_interfaces(self):
         """By default views are registered for the IBatchActionsMarker
            interface, but in case it is needed to register different views,

--- a/src/collective/eeafaceted/batchactions/browser/viewlets.py
+++ b/src/collective/eeafaceted/batchactions/browser/viewlets.py
@@ -24,6 +24,12 @@ class BatchActionsViewlet(ViewletBase):
            several table on same page."""
         return "select_item"
 
+    @property
+    def section(self):
+        """The name of the section, useful to manage batch actions
+           displayed on several views with same context."""
+        return "default"
+
     def _get_marker_interfaces(self):
         """By default views are registered for the IBatchActionsMarker
            interface, but in case it is needed to register different views,
@@ -57,9 +63,10 @@ class BatchActionsViewlet(ViewletBase):
         registered_actions = set([action.name for action in registered_actions])
         # now check that action is available
         actions = []
+        section = self.section
         for registered_action in registered_actions:
             form = getMultiAdapter((self.context, self.request), name=registered_action)
-            if form.available():
+            if form.available() and form.section == section:
                 actions.append({
                     'name': registered_action,
                     'button_with_icon': form.button_with_icon,

--- a/src/collective/eeafaceted/batchactions/browser/viewlets.py
+++ b/src/collective/eeafaceted/batchactions/browser/viewlets.py
@@ -66,7 +66,7 @@ class BatchActionsViewlet(ViewletBase):
         section = self.section
         for registered_action in registered_actions:
             form = getMultiAdapter((self.context, self.request), name=registered_action)
-            if form.available() and form.section == section:
+            if form.section == section and form.available():
                 actions.append({
                     'name': registered_action,
                     'button_with_icon': form.button_with_icon,

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -55,6 +55,8 @@ class BaseBatchActionForm(Form):
     # easy way to hide the "Apply" button when required conditions
     # are not met for the action to be applied
     do_apply = True
+    # the title of the apply button to fit current action
+    apply_button_title = _('Apply')
     # this will add a specific class to the generated button action
     # so it is possible to skin it with an icon
     button_with_icon = False
@@ -69,6 +71,10 @@ class BaseBatchActionForm(Form):
 
     def _update(self):
         """Method to override if you need to do something in the update."""
+        return
+
+    def _final_update(self):
+        """Method to override if you need to do something when everything have been updated."""
         return
 
     def _update_widgets(self):
@@ -106,6 +112,9 @@ class BaseBatchActionForm(Form):
         self._update()
         super(BaseBatchActionForm, self).update()
         self._update_widgets()
+        if 'apply' in self.actions:
+            self.actions['apply'].title = self.apply_button_title
+        self._final_update()
 
     @button.buttonAndHandler(_(u'Apply'), name='apply', condition=lambda fi: fi.do_apply)
     def handleApply(self, action):
@@ -195,6 +204,7 @@ class DeleteBatchActionForm(BaseBatchActionForm):
     label = _(u"Delete elements")
     weight = 5
     button_with_icon = True
+    apply_button_title = _('delete-batch-action-but')
 
     def get_deletable_elements(self):
         """ """

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -120,14 +120,14 @@ class BaseBatchActionForm(Form):
                 repr(self.label), len(self.brains))
             fplog('apply_batch_action', extras=extras)
             # call the method that does the job
-            self._apply(**data)
+            applied = self._apply(**data)
             # redirect if not using an overlay
             if not self.request.form.get('ajax_load', ''):
                 self.request.response.redirect(self.request.form['form.widgets.referer'])
             else:
                 # make sure we return nothing, taken into account by ajax query
                 self.request.RESPONSE.setStatus(204)
-                return ""
+                return applied or ""
 
     @button.buttonAndHandler(PMF(u'Cancel'), name='cancel')
     def handleCancel(self, action):
@@ -214,7 +214,6 @@ class DeleteBatchActionForm(BaseBatchActionForm):
 
     def _apply(self, **data):
         """ """
-        import ipdb; ipdb.set_trace()
         for brain in self.brains:
             obj = brain.getObject()
             api.content.delete(obj)

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -56,6 +56,8 @@ class BaseBatchActionForm(Form):
     button_with_icon = False
     overlay = True
     weight = 100
+    # useful when dispalying batch actions on several views for same context
+    section = "default"
 
     def available(self):
         """Will the action be available for current context?"""

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -56,7 +56,7 @@ class BaseBatchActionForm(Form):
     # are not met for the action to be applied
     do_apply = True
     # the title of the apply button to fit current action
-    apply_button_title = _('Apply')
+    apply_button_title = None
     # this will add a specific class to the generated button action
     # so it is possible to skin it with an icon
     button_with_icon = False
@@ -112,7 +112,7 @@ class BaseBatchActionForm(Form):
         self._update()
         super(BaseBatchActionForm, self).update()
         self._update_widgets()
-        if 'apply' in self.actions:
+        if self.apply_button_title is not None and 'apply' in self.actions:
             self.actions['apply'].title = self.apply_button_title
         self._final_update()
 

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -206,29 +206,32 @@ class DeleteBatchActionForm(BaseBatchActionForm):
     button_with_icon = True
     apply_button_title = _('delete-batch-action-but')
 
-    def get_deletable_elements(self):
+    def _get_deletable_elements(self):
         """ """
-        deletables = [brain for brain in self.brains
-                      if _checkPermission(DeleteObjects, brain.getObject())]
+        objs = [brain.getObject() for brain in self.brains]
+        deletables = [obj for obj in objs
+                      if _checkPermission(DeleteObjects, obj)]
         return deletables
+
+    def _update(self):
+        """ """
+        self.deletables = self._get_deletable_elements()
 
     @property
     def description(self):
         """ """
-        deletables = self.get_deletable_elements()
-        if len(deletables) < len(self.brains):
-            not_deletables = len(self.brains) - len(deletables)
+        if len(self.deletables) < len(self.brains):
+            not_deletables = len(self.brains) - len(self.deletables)
             return _('This action will only affect ${deletable_number} element(s), indeed '
                      'you do not have the permission to delete ${not_deletable_number} element(s).',
-                     mapping={'deletable_number': len(deletables),
+                     mapping={'deletable_number': len(self.deletables),
                               'not_deletable_number': not_deletables, })
         else:
             return super(DeleteBatchActionForm, self).description
 
     def _apply(self, **data):
         """ """
-        for brain in self.brains:
-            obj = brain.getObject()
+        for obj in self.deletables:
             api.content.delete(obj)
 
 

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -52,6 +52,8 @@ class BaseBatchActionForm(Form):
     fields['referer'].mode = HIDDEN_MODE
     ignoreContext = True
     brains = []
+    # easy way to hide the "Apply" button when required conditions
+    # are not met for the action to be applied
     do_apply = True
     # this will add a specific class to the generated button action
     # so it is possible to skin it with an icon

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -126,7 +126,8 @@ class BaseBatchActionForm(Form):
                 self.request.response.redirect(self.request.form['form.widgets.referer'])
             else:
                 # make sure we return nothing, taken into account by ajax query
-                self.request.RESPONSE.setStatus(204)
+                if not applied:
+                    self.request.RESPONSE.setStatus(204)
                 return applied or ""
 
     @button.buttonAndHandler(PMF(u'Cancel'), name='cancel')

--- a/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
+++ b/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-19 14:23+0000\n"
+"POT-Creation-Date: 2021-05-25 10:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.eeafaceted.batchactions\n"
 
-#: ./browser/views.py:265
+#: ./browser/views.py:279
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:296
+#: ./browser/views.py:310
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:108
+#: ./browser/views.py:59
 msgid "Apply"
 msgstr ""
 
-#: ./browser/views.py:263
+#: ./browser/views.py:277
 msgid "Batch action choice"
 msgstr ""
 
@@ -37,23 +37,23 @@ msgstr ""
 msgid "Batch action form"
 msgstr ""
 
-#: ./browser/views.py:361
+#: ./browser/views.py:375
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:231
+#: ./browser/views.py:245
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:139
+#: ./browser/views.py:151
 msgid "Batch state change"
 msgstr ""
 
-#: ./browser/views.py:176
+#: ./browser/views.py:188
 msgid "Comment"
 msgstr ""
 
-#: ./browser/views.py:192
+#: ./browser/views.py:204
 msgid "Delete elements"
 msgstr ""
 
@@ -61,43 +61,43 @@ msgstr ""
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr ""
 
-#: ./browser/views.py:172
+#: ./browser/views.py:184
 msgid "No common or available transition. Modify your selection."
 msgstr ""
 
-#: ./browser/views.py:177
+#: ./browser/views.py:189
 msgid "Optional comment to display in history"
 msgstr ""
 
-#: ./browser/views.py:268
+#: ./browser/views.py:282
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:266
+#: ./browser/views.py:280
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:289
+#: ./browser/views.py:303
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:267
+#: ./browser/views.py:281
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:401
+#: ./browser/views.py:415
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:393
+#: ./browser/views.py:407
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:297
+#: ./browser/views.py:311
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:290
+#: ./browser/views.py:304
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -105,15 +105,15 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr ""
 
-#: ./browser/views.py:80
+#: ./browser/views.py:88
 msgid "This action will affect ${number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:207
+#: ./browser/views.py:221
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:169
+#: ./browser/views.py:181
 msgid "Transition"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "collective.eeafaceted.batchactions tests"
 msgstr ""
 
-#. Default: "Delete"
+#: ./browser/views.py:207
 msgid "delete-batch-action-but"
 msgstr ""
 

--- a/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
+++ b/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-12-16 14:17+0000\n"
+"POT-Creation-Date: 2021-05-19 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,83 +17,87 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.eeafaceted.batchactions\n"
 
-#: ./browser/views.py:230
+#: ./browser/views.py:265
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:261
+#: ./browser/views.py:296
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:104
+#: ./browser/views.py:108
 msgid "Apply"
 msgstr ""
 
-#: ./browser/views.py:228
+#: ./browser/views.py:263
 msgid "Batch action choice"
 msgstr ""
 
-#: ./browser/views.py:47
+#: ./browser/views.py:49
 msgid "Batch action form"
 msgstr ""
 
-#: ./browser/views.py:326
+#: ./browser/views.py:361
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:196
+#: ./browser/views.py:231
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:135
+#: ./browser/views.py:139
 msgid "Batch state change"
 msgstr ""
 
-#: ./browser/views.py:172
+#: ./browser/views.py:176
 msgid "Comment"
+msgstr ""
+
+#: ./browser/views.py:192
+msgid "Delete elements"
 msgstr ""
 
 #: ./configure.zcml:32
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr ""
 
-#: ./browser/views.py:168
+#: ./browser/views.py:172
 msgid "No common or available transition. Modify your selection."
 msgstr ""
 
-#: ./browser/views.py:173
+#: ./browser/views.py:177
 msgid "Optional comment to display in history"
 msgstr ""
 
-#: ./browser/views.py:233
+#: ./browser/views.py:268
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:231
+#: ./browser/views.py:266
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:254
+#: ./browser/views.py:289
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:232
+#: ./browser/views.py:267
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:366
+#: ./browser/views.py:401
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:358
+#: ./browser/views.py:393
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:262
+#: ./browser/views.py:297
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:255
+#: ./browser/views.py:290
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -101,11 +105,15 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr ""
 
-#: ./browser/views.py:76
+#: ./browser/views.py:80
 msgid "This action will affect ${number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:165
+#: ./browser/views.py:207
+msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
+msgstr ""
+
+#: ./browser/views.py:169
 msgid "Transition"
 msgstr ""
 
@@ -119,6 +127,10 @@ msgstr ""
 
 #: ./testing.zcml:18
 msgid "collective.eeafaceted.batchactions tests"
+msgstr ""
+
+#. Default: "Delete"
+msgid "delete-batch-action-but"
 msgstr ""
 
 #. Default: "Change labels"

--- a/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-12-16 14:17+0000\n"
+"POT-Creation-Date: 2021-05-19 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,83 +14,87 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:230
+#: ./browser/views.py:265
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:261
+#: ./browser/views.py:296
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:104
+#: ./browser/views.py:108
 msgid "Apply"
 msgstr "Apply"
 
-#: ./browser/views.py:228
+#: ./browser/views.py:263
 msgid "Batch action choice"
 msgstr ""
 
-#: ./browser/views.py:47
+#: ./browser/views.py:49
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:326
+#: ./browser/views.py:361
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:196
+#: ./browser/views.py:231
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:135
+#: ./browser/views.py:139
 msgid "Batch state change"
 msgstr "Batch state change"
 
-#: ./browser/views.py:172
+#: ./browser/views.py:176
 msgid "Comment"
 msgstr "Comment"
+
+#: ./browser/views.py:192
+msgid "Delete elements"
+msgstr ""
 
 #: ./configure.zcml:32
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:168
+#: ./browser/views.py:172
 msgid "No common or available transition. Modify your selection."
 msgstr "No common or available transition. Modify your selection."
 
-#: ./browser/views.py:173
+#: ./browser/views.py:177
 msgid "Optional comment to display in history"
 msgstr "Optional comment to display in history"
 
-#: ./browser/views.py:233
+#: ./browser/views.py:268
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:231
+#: ./browser/views.py:266
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:254
+#: ./browser/views.py:289
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:232
+#: ./browser/views.py:267
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:366
+#: ./browser/views.py:401
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:358
+#: ./browser/views.py:393
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:262
+#: ./browser/views.py:297
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:255
+#: ./browser/views.py:290
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -98,11 +102,15 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:76
+#: ./browser/views.py:80
 msgid "This action will affect ${number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:165
+#: ./browser/views.py:207
+msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
+msgstr ""
+
+#: ./browser/views.py:169
 msgid "Transition"
 msgstr "Transition"
 
@@ -117,6 +125,10 @@ msgstr "collective.eeafaceted.batchactions"
 #: ./testing.zcml:18
 msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
+
+#. Default: "Delete"
+msgid "delete-batch-action-but"
+msgstr ""
 
 #. Default: "Change labels"
 msgid "labels-batch-action-but"

--- a/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-19 14:23+0000\n"
+"POT-Creation-Date: 2021-05-25 10:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,19 +14,19 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:265
+#: ./browser/views.py:279
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:296
+#: ./browser/views.py:310
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:108
+#: ./browser/views.py:59
 msgid "Apply"
 msgstr "Apply"
 
-#: ./browser/views.py:263
+#: ./browser/views.py:277
 msgid "Batch action choice"
 msgstr ""
 
@@ -34,23 +34,23 @@ msgstr ""
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:361
+#: ./browser/views.py:375
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:231
+#: ./browser/views.py:245
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:139
+#: ./browser/views.py:151
 msgid "Batch state change"
 msgstr "Batch state change"
 
-#: ./browser/views.py:176
+#: ./browser/views.py:188
 msgid "Comment"
 msgstr "Comment"
 
-#: ./browser/views.py:192
+#: ./browser/views.py:204
 msgid "Delete elements"
 msgstr ""
 
@@ -58,43 +58,43 @@ msgstr ""
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:172
+#: ./browser/views.py:184
 msgid "No common or available transition. Modify your selection."
 msgstr "No common or available transition. Modify your selection."
 
-#: ./browser/views.py:177
+#: ./browser/views.py:189
 msgid "Optional comment to display in history"
 msgstr "Optional comment to display in history"
 
-#: ./browser/views.py:268
+#: ./browser/views.py:282
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:266
+#: ./browser/views.py:280
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:289
+#: ./browser/views.py:303
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:267
+#: ./browser/views.py:281
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:401
+#: ./browser/views.py:415
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:393
+#: ./browser/views.py:407
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:297
+#: ./browser/views.py:311
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:290
+#: ./browser/views.py:304
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -102,15 +102,15 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:80
+#: ./browser/views.py:88
 msgid "This action will affect ${number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:207
+#: ./browser/views.py:221
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:169
+#: ./browser/views.py:181
 msgid "Transition"
 msgstr "Transition"
 
@@ -127,6 +127,7 @@ msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
 
 #. Default: "Delete"
+#: ./browser/views.py:207
 msgid "delete-batch-action-but"
 msgstr ""
 

--- a/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -104,7 +104,7 @@ msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
 #: ./browser/views.py:80
 msgid "This action will affect ${number} element(s)."
-msgstr "Cette action sera appliquée sur ${number} élément(s)."
+msgstr "Cette action concerne ${number} élément(s)."
 
 #: ./browser/views.py:207
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."

--- a/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-19 14:23+0000\n"
+"POT-Creation-Date: 2021-05-25 10:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,19 +14,19 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:265
+#: ./browser/views.py:279
 msgid "Add items"
 msgstr "Ajouter des éléments"
 
-#: ./browser/views.py:296
+#: ./browser/views.py:310
 msgid "Added values"
 msgstr "Éléments à ajouter / fixés"
 
-#: ./browser/views.py:108
+#: ./browser/views.py:59
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ./browser/views.py:263
+#: ./browser/views.py:277
 msgid "Batch action choice"
 msgstr "Choix de l'action à effectuer"
 
@@ -34,23 +34,23 @@ msgstr "Choix de l'action à effectuer"
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:361
+#: ./browser/views.py:375
 msgid "Batch contact field change"
 msgstr "Changement de contact par lot"
 
-#: ./browser/views.py:231
+#: ./browser/views.py:245
 msgid "Batch labels change"
 msgstr "Changer les étiquettes par lot"
 
-#: ./browser/views.py:139
+#: ./browser/views.py:151
 msgid "Batch state change"
 msgstr "Changer l'état par lot"
 
-#: ./browser/views.py:176
+#: ./browser/views.py:188
 msgid "Comment"
 msgstr "Commentaire"
 
-#: ./browser/views.py:192
+#: ./browser/views.py:204
 msgid "Delete elements"
 msgstr "Supprimer les éléments par lot"
 
@@ -58,43 +58,43 @@ msgstr "Supprimer les éléments par lot"
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:172
+#: ./browser/views.py:184
 msgid "No common or available transition. Modify your selection."
 msgstr "<span style='color: red;'>Aucune transition commune ou valide. Recommencez en modifiant votre sélection.</span>"
 
-#: ./browser/views.py:177
+#: ./browser/views.py:189
 msgid "Optional comment to display in history"
 msgstr "Commentaire optionnel qui sera affiché dans l'historique."
 
-#: ./browser/views.py:268
+#: ./browser/views.py:282
 msgid "Overwrite"
 msgstr "Écraser le contenu avec les éléments choisis"
 
-#: ./browser/views.py:266
+#: ./browser/views.py:280
 msgid "Remove items"
 msgstr "Retirer des éléments"
 
-#: ./browser/views.py:289
+#: ./browser/views.py:303
 msgid "Removed values"
 msgstr "Éléments à retirer"
 
-#: ./browser/views.py:267
+#: ./browser/views.py:281
 msgid "Replace some items by others"
 msgstr "Remplacer des éléments par d'autres"
 
-#: ./browser/views.py:401
+#: ./browser/views.py:415
 msgid "Search and select the values to add."
 msgstr "Chercher et sélectionner des contacts à ajouter."
 
-#: ./browser/views.py:393
+#: ./browser/views.py:407
 msgid "Search and select the values to remove, if necessary."
 msgstr "Chercher et sélectionner des contacts à retirer, si nécessaire."
 
-#: ./browser/views.py:297
+#: ./browser/views.py:311
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à ajouter. Une étiquette utilisateur est indiquée par (*)."
 
-#: ./browser/views.py:290
+#: ./browser/views.py:304
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est indiquée par (*)."
 
@@ -102,15 +102,15 @@ msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est 
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:80
+#: ./browser/views.py:88
 msgid "This action will affect ${number} element(s)."
 msgstr "Cette action concerne ${number} élément(s)."
 
-#: ./browser/views.py:207
+#: ./browser/views.py:221
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr "Cette action ne sera appliquée que sur ${deletable_number} élément(s) sélectionné(s) car vous n'avez pas la permission de supprimer les autres ${not_deletable_number} élément(s)."
 
-#: ./browser/views.py:169
+#: ./browser/views.py:181
 msgid "Transition"
 msgstr "Transition"
 
@@ -127,6 +127,7 @@ msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
 
 #. Default: "Delete"
+#: ./browser/views.py:207
 msgid "delete-batch-action-but"
 msgstr "Supprimer"
 

--- a/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-12-16 14:17+0000\n"
+"POT-Creation-Date: 2021-05-19 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,83 +14,87 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:230
+#: ./browser/views.py:265
 msgid "Add items"
 msgstr "Ajouter des éléments"
 
-#: ./browser/views.py:261
+#: ./browser/views.py:296
 msgid "Added values"
 msgstr "Éléments à ajouter / fixés"
 
-#: ./browser/views.py:104
+#: ./browser/views.py:108
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ./browser/views.py:228
+#: ./browser/views.py:263
 msgid "Batch action choice"
 msgstr "Choix de l'action à effectuer"
 
-#: ./browser/views.py:47
+#: ./browser/views.py:49
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:326
+#: ./browser/views.py:361
 msgid "Batch contact field change"
 msgstr "Changement de contact par lot"
 
-#: ./browser/views.py:196
+#: ./browser/views.py:231
 msgid "Batch labels change"
 msgstr "Changer les étiquettes par lot"
 
-#: ./browser/views.py:135
+#: ./browser/views.py:139
 msgid "Batch state change"
 msgstr "Changer l'état par lot"
 
-#: ./browser/views.py:172
+#: ./browser/views.py:176
 msgid "Comment"
 msgstr "Commentaire"
+
+#: ./browser/views.py:192
+msgid "Delete elements"
+msgstr "Supprimer les éléments par lot"
 
 #: ./configure.zcml:32
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:168
+#: ./browser/views.py:172
 msgid "No common or available transition. Modify your selection."
 msgstr "<span style='color: red;'>Aucune transition commune ou valide. Recommencez en modifiant votre sélection.</span>"
 
-#: ./browser/views.py:173
+#: ./browser/views.py:177
 msgid "Optional comment to display in history"
 msgstr "Commentaire optionnel qui sera affiché dans l'historique."
 
-#: ./browser/views.py:233
+#: ./browser/views.py:268
 msgid "Overwrite"
 msgstr "Écraser le contenu avec les éléments choisis"
 
-#: ./browser/views.py:231
+#: ./browser/views.py:266
 msgid "Remove items"
 msgstr "Retirer des éléments"
 
-#: ./browser/views.py:254
+#: ./browser/views.py:289
 msgid "Removed values"
 msgstr "Éléments à retirer"
 
-#: ./browser/views.py:232
+#: ./browser/views.py:267
 msgid "Replace some items by others"
 msgstr "Remplacer des éléments par d'autres"
 
-#: ./browser/views.py:366
+#: ./browser/views.py:401
 msgid "Search and select the values to add."
 msgstr "Chercher et sélectionner des contacts à ajouter."
 
-#: ./browser/views.py:358
+#: ./browser/views.py:393
 msgid "Search and select the values to remove, if necessary."
 msgstr "Chercher et sélectionner des contacts à retirer, si nécessaire."
 
-#: ./browser/views.py:262
+#: ./browser/views.py:297
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à ajouter. Une étiquette utilisateur est indiquée par (*)."
 
-#: ./browser/views.py:255
+#: ./browser/views.py:290
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est indiquée par (*)."
 
@@ -98,11 +102,15 @@ msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est 
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:76
+#: ./browser/views.py:80
 msgid "This action will affect ${number} element(s)."
 msgstr "Cette action sera appliquée sur ${number} élément(s)."
 
-#: ./browser/views.py:165
+#: ./browser/views.py:207
+msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
+msgstr "Cette action ne sera appliquée que sur ${deletable_number} élément(s) sélectionné(s) car vous n'avez pas la permission de supprimer les autres ${not_deletable_number} élément(s)."
+
+#: ./browser/views.py:169
 msgid "Transition"
 msgstr "Transition"
 
@@ -117,6 +125,10 @@ msgstr "collective.eeafaceted.batchactions"
 #: ./testing.zcml:18
 msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
+
+#. Default: "Delete"
+msgid "delete-batch-action-but"
+msgstr "Supprimer"
 
 #. Default: "Change labels"
 msgid "labels-batch-action-but"

--- a/src/collective/eeafaceted/batchactions/locales/manual.pot
+++ b/src/collective/eeafaceted/batchactions/locales/manual.pot
@@ -17,3 +17,8 @@ msgstr ""
 #. Default: "Change state"
 msgid "transition-batch-action-but"
 msgstr ""
+
+#. Default: "Delete"
+msgid "delete-batch-action-but"
+msgstr ""
+

--- a/src/collective/eeafaceted/batchactions/testing.py
+++ b/src/collective/eeafaceted/batchactions/testing.py
@@ -15,6 +15,7 @@ from plone.testing import z2
 import collective.eeafaceted.batchactions
 import pkg_resources
 
+
 try:
     pkg_resources.get_distribution('plone.app.contenttypes')
 except pkg_resources.DistributionNotFound:

--- a/src/collective/eeafaceted/batchactions/testing.zcml
+++ b/src/collective/eeafaceted/batchactions/testing.zcml
@@ -14,25 +14,30 @@
       title="collective.eeafaceted.batchactions tests"
       directory="profiles/testing"
       description="Steps to ease tests of collective.eeafaceted.batchactions"
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      />
+      provides="Products.GenericSetup.interfaces.EXTENSION" />
 
-    <browser:page
-        for="collective.eeafaceted.batchactions.tests.interfaces.IBatchActionsSpecificMarker"
-        name="testing-batch-action"
-        class=".tests.views.TestingBatchActionForm"
-        permission="zope2.View" />
+  <browser:page
+      for="collective.eeafaceted.batchactions.tests.interfaces.IBatchActionsSpecificMarker"
+      name="testing-batch-action"
+      class=".tests.views.TestingBatchActionForm"
+      permission="zope2.View" />
 
-    <browser:page
-        for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
-        name="labels-batch-action"
-        class=".browser.views.LabelsBatchActionForm"
-        permission="zope2.View" />
+  <browser:page
+      for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
+      name="labels-batch-action"
+      class=".browser.views.LabelsBatchActionForm"
+      permission="zope2.View" />
 
-    <browser:page
-        for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
-        name="contact-batch-action"
-        class=".tests.views.ContactBatchActionForm"
-        permission="zope2.View" />
+  <browser:page
+      for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
+      name="contact-batch-action"
+      class=".tests.views.ContactBatchActionForm"
+      permission="zope2.View" />
+
+  <browser:page
+      for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
+      name="delete-batch-action"
+      class=".browser.views.DeleteBatchActionForm"
+      permission="zope2.View" />
 
 </configure>

--- a/src/collective/eeafaceted/batchactions/tests/base.py
+++ b/src/collective/eeafaceted/batchactions/tests/base.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 from collective.eeafaceted.batchactions import testing
 from collective.eeafaceted.batchactions.interfaces import IBatchActionsMarker
 from eea.facetednavigation.layout.interfaces import IFacetedLayout
 from plone import api
 from zope.interface import alsoProvides
+
+import unittest
 
 
 class BaseTestCase(unittest.TestCase):

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -153,6 +153,12 @@ class TestActions(BaseTestCase):
         self.eea_folder.manage_permission(DeleteObjects, [])
         self.assertFalse(_checkPermission(DeleteObjects, self.eea_folder))
         # set 'uids' in form, 2 deletable elements, one not deletable
+        doc_uids = u"{0},{1}".format(self.doc1.UID(), self.doc2.UID())
+        self.request.form['form.widgets.uids'] = doc_uids
+        form = self.eea_folder.restrictedTraverse('delete-batch-action')
+        form.update()
+        self.assertTrue("This action will affect 2 element(s)." in form.render())
+        # when some not deletable a specific description is displayed
         doc_uids = u"{0},{1},{2}".format(self.doc1.UID(), self.doc2.UID(), self.eea_folder.UID())
         self.request.form['form.widgets.uids'] = doc_uids
         form = self.eea_folder.restrictedTraverse('delete-batch-action')
@@ -160,6 +166,7 @@ class TestActions(BaseTestCase):
         self.assertTrue("This action will only affect 2 element(s), "
                         "indeed you do not have the permission to delete 1 element(s)."
                         in form.render())
+
         # apply button title is changed using the form.apply_button_title
         self.assertEqual(form.actions['apply'].title, u'delete-batch-action-but')
         # apply, 2 elements are deleted

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from zope.component import getMultiAdapter
 from collective.eeafaceted.batchactions.tests.base import BaseTestCase
 from plone import api
+from zope.component import getMultiAdapter
 
 
 class TestActions(BaseTestCase):

--- a/src/collective/eeafaceted/batchactions/tests/test_labels_form.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_labels_form.py
@@ -7,9 +7,9 @@ from ftw.labels.interfaces import ILabelJar
 from ftw.labels.interfaces import ILabelRoot
 from ftw.labels.interfaces import ILabelSupport
 from plone import api
-from zope.interface import alsoProvides
 from plone.app.testing import login
 from plone.app.testing import TEST_USER_NAME
+from zope.interface import alsoProvides
 
 
 class TestLabels(BaseTestCase):

--- a/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
@@ -35,6 +35,11 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(self.eea_folder)
         self.assertTrue(viewlet.available())
 
+    def test_viewlet_select_item_name(self):
+        """Name of the CheckboxColumn."""
+        viewlet = self._get_viewlet(self.eea_folder)
+        self.assertEqual(viewlet.select_item_name, 'select_item')
+
     def test_viewlet_only_rendered_on_IBatchActionsMarker(self):
         """ """
         folder = api.content.create(
@@ -71,7 +76,8 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(self.eea_folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
+             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])
         # returned action names are traversable to get the form
@@ -105,7 +111,8 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
+             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])
 
@@ -113,7 +120,8 @@ class TestViewlets(BaseTestCase):
         alsoProvides(folder, IBatchActionsSpecificMarker)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
+             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
              {'name': 'testing-batch-action', 'button_with_icon': True, 'overlay': False, 'weight': 100}])
@@ -126,6 +134,7 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(self.eea_folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
+             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])

--- a/src/collective/eeafaceted/batchactions/utils.py
+++ b/src/collective/eeafaceted/batchactions/utils.py
@@ -5,6 +5,7 @@ from AccessControl import getSecurityManager
 from collective.eeafaceted.batchactions import _
 from imio.helpers.content import uuidsToCatalogBrains
 
+
 cannot_modify_field_msg = _(u"You can't change this field on selected items. Modify your selection.")
 
 


### PR DESCRIPTION
Salut @sgeulette 

pourrais tu review cela?

En fait çà permet de définir plusieurs fois le viewlet "batchactions" sur la même page, nécessaire de:

- permettre de changer le nom la colonne checkboxes pour avoir des listes différentes
- avoir la notion de "section" sur le viewlet et de pouvoir définir une section pour des actions, çà facilite l'association d'une action à un viewlet

En outre j'ai du faire qq autres changements, et pas fait de PR séparée...

- permettre de changer le titre du bouton "Apply" facilement, comme çà je met "Télécharger" ou "Supprimer" en fonction du usecase, c'est plus parlant (c'était surtout pour le "Supprimer")
- possibilité de recevoir une réponse, c'est autour du "applied = ...", ici un fichier à télécharger, une PR dans imio.helpers est liée à çà aussi

Pourrais-tu tester qu'avec cette branche et imio.helpers branche https://github.com/IMIO/imio.helpers/tree/PM-3355_fix_js_submitFormHelperOnsuccessDefault_to_handle_binary_response tout fonctionne chez toi pour les batchactions existantes?
Ici j'ai ajouté un proto de "Delete", surchargé dans PM car on utilise "OwnDelete" comme dans imio.actionspanel, pas activé par défaut donc.
Merci!
Gauthier