### PR TITLE
Added `BaseARUOBatchActionForm`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,12 @@ Changelog
 1.13 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Added `BaseARUOBatchActionForm`, a class factorizing the action that
+  `add/remove/update/overwrite` values on an attribute of an object
+  (originally used for the `LabelsBatchActionForm`) so it is easier to reuse
+  for other similar actions. `LabelsBatchActionForm` is now based on that
+  `BaseARUOBatchActionForm`.
+  [gbastien]
 
 1.12 (2023-06-27)
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
   for other similar actions. `LabelsBatchActionForm` is now based on that
   `BaseARUOBatchActionForm`.
   [gbastien]
+- Activated `delete-batch-action` for zope admin
+  [sgeulette]
 
 1.12 (2023-06-27)
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'setuptools',
         'collective.eeafaceted.z3ctable>=2.0',
         'imio.helpers',
+        'imio.pyutils',
         'plone.formwidget.masterselect<2.0.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import os
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
+
 long_description = \
     read('README.rst') + '\n\n' + read('CHANGES.rst')
 

--- a/src/collective/eeafaceted/batchactions/browser/configure.zcml
+++ b/src/collective/eeafaceted/batchactions/browser/configure.zcml
@@ -28,10 +28,10 @@
         class=".views.UpdateWFRoleMappingsActionForm"
         permission="zope2.View" />
 
-    <!--browser:page
+    <browser:page
         for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
         name="delete-batch-action"
         class=".views.DeleteBatchActionForm"
-        permission="zope2.View" /-->
+        permission="zope2.View" />
 
 </configure>

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -289,13 +289,13 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
 
     @property
     def _removed_values_description(self):
-        """The description (msgid) of the "removed_values" field."""
-        return u"Select the values to remove."
+        """The translated description of the "removed_values" field."""
+        return _(u"Select the values to remove.")
 
     @property
     def _added_values_description(self):
-        """The description (msgid) of the "added_values" field."""
-        return u"Select the values to add."
+        """The translated description of the "added_values" field."""
+        return _(u"Select the values to add.")
 
     @property
     def _may_apply(self):
@@ -343,14 +343,14 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
             self.fields += Fields(schema.List(
                 __name__='removed_values',
                 title=_(u"Removed values"),
-                description=_(self._removed_values_description),
+                description=self._removed_values_description,
                 required=False,
                 value_type=schema.Choice(vocabulary=self._vocabulary),
             ))
             self.fields += Fields(schema.List(
                 __name__='added_values',
                 title=_(u"Added values"),
-                description=_(self._added_values_description),
+                description=self._added_values_description,
                 required=False,
                 value_type=schema.Choice(vocabulary=self._vocabulary),
             ))
@@ -403,11 +403,11 @@ class LabelsBatchActionForm(BaseARUOBatchActionForm):
 
     @property
     def _removed_values_description(self):
-        return u"Select the values to remove. A personal label is represented by (*)."
+        return _(u"Select the values to remove. A personal label is represented by (*).")
 
     @property
     def _added_values_description(self):
-        return u"Select the values to add. A personal label is represented by (*)."
+        return _(u"Select the values to add. A personal label is represented by (*).")
 
     @property
     def _may_apply(self):

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -218,6 +218,7 @@ class DeleteBatchActionForm(BaseBatchActionForm):
     weight = 5
     button_with_icon = True
     apply_button_title = _('delete-batch-action-but')
+    available_for_zope_admin = True
 
     def _get_deletable_elements(self):
         """ """

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -277,6 +277,10 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     keep_vocabulary_order = True
     # the name of the attribute that will be modified on the object
     modified_attr_name = None
+    # translated description of the "added_values" field
+    added_values_description = _(u"Select the values to add.")
+    # translated description of the "removed_values" field
+    removed_values_description = _(u"Select the values to remove.")
     # indexes to reindex when values changed
     indexes = []
     # call the "modified" event on object at the end if it was modified?
@@ -284,21 +288,10 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     # can the resulting set values be empty?
     required = False
 
-    @property
     def _vocabulary(self):
         """A SimpleVocabulary instance."""
+        return None
 
-    @property
-    def _removed_values_description(self):
-        """The translated description of the "removed_values" field."""
-        return _(u"Select the values to remove.")
-
-    @property
-    def _added_values_description(self):
-        """The translated description of the "added_values" field."""
-        return _(u"Select the values to add.")
-
-    @property
     def _may_apply(self):
         """The condition for the action to be applied."""
         return is_permitted(self.brains)
@@ -308,7 +301,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
         return True if not self.required or values else False
 
     def _update(self):
-        self.do_apply = self._may_apply
+        self.do_apply = self._may_apply()
         self.fields += Fields(MasterSelectField(
             __name__='action_choice',
             title=_(u'Batch action choice'),
@@ -338,16 +331,16 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
             self.fields += Fields(schema.List(
                 __name__='removed_values',
                 title=_(u"Removed values"),
-                description=self._removed_values_description,
+                description=self.removed_values_description,
                 required=False,
-                value_type=schema.Choice(vocabulary=self._vocabulary),
+                value_type=schema.Choice(vocabulary=self._vocabulary()),
             ))
             self.fields += Fields(schema.List(
                 __name__='added_values',
                 title=_(u"Added values"),
-                description=self._added_values_description,
+                description=self.added_values_description,
                 required=False,
-                value_type=schema.Choice(vocabulary=self._vocabulary),
+                value_type=schema.Choice(vocabulary=self._vocabulary()),
             ))
             self.fields["removed_values"].widgetFactory = CheckBoxFieldWidget
             self.fields["added_values"].widgetFactory = CheckBoxFieldWidget
@@ -393,20 +386,14 @@ class LabelsBatchActionForm(BaseARUOBatchActionForm):
 
     label = _(u"Batch labels change")
     weight = 20
+    removed_values_description = \
+        _(u"Select the values to remove. A personal label is represented by (*).")
+    added_values_description = \
+        _(u"Select the values to add. A personal label is represented by (*).")
 
-    @property
     def _vocabulary(self):
         return self.labels_voc
 
-    @property
-    def _removed_values_description(self):
-        return _(u"Select the values to remove. A personal label is represented by (*).")
-
-    @property
-    def _added_values_description(self):
-        return _(u"Select the values to add. A personal label is represented by (*).")
-
-    @property
     def _may_apply(self):
         self.labels_voc, self.p_labels, self.g_labels = self.get_labels_vocabulary()
         return len(self.labels_voc._terms) and has_interface(self.brains, ILabelSupport)

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -289,7 +289,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     required = False
 
     def _vocabulary(self):
-        """A SimpleVocabulary instance."""
+        """A SimpleVocabulary instance or a vocabulary name."""
         return None
 
     def _may_apply(self):
@@ -375,8 +375,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
                     if not self._validate(obj, items):
                         continue
                     if self.keep_vocabulary_order:
-                        vocab = self.fields['added_values'].field.value_type.vocabulary
-                        all_values = [term.value for term in vocab._terms]
+                        all_values = [term.value for term in self.widgets['added_values'].terms]
                         term_indexes = [all_values.index(item) for item in items]
                         items = sort_by_indexes(list(items), term_indexes)
                     setattr(obj, self.modified_attr_name, items)

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -378,7 +378,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
                     if data['action_choice'] in ('add', 'replace'):
                         items = items.union(data['added_values'])
                 # only update if values changed
-                if list(getattr(obj, self._modified_attr_name)) != list(items):
+                if sorted(list(getattr(obj, self._modified_attr_name))) != sorted(list(items)):
                     if self._should_keep_vocabulary_order:
                         vocab = self.fields['added_values'].field.value_type.vocabulary
                         all_values = [term.value for term in vocab._terms]

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -289,8 +289,12 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     required = False
 
     def _vocabulary(self):
-        """A SimpleVocabulary instance or a vocabulary name."""
+        """A SimpleVocabulary instance or a vocabulary name, containing the values to add/set."""
         return None
+
+    def _remove_vocabulary(self):
+        """A SimpleVocabulary instance or a vocabulary name, containing the values to remove/replace."""
+        return self._vocabulary()
 
     def _may_apply(self):
         """The condition for the action to be applied."""
@@ -320,7 +324,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
                 {'name': 'added_values',
                  'slaveID': '#form-widgets-added_values',
                  'action': 'hide',
-                 'hide_values': (u'remove'),
+                 'hide_values': (u'remove',),
                  'siblings': True,
                  },
             ),
@@ -333,7 +337,7 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
                 title=_(u"Removed values"),
                 description=self.removed_values_description,
                 required=False,
-                value_type=schema.Choice(vocabulary=self._vocabulary()),
+                value_type=schema.Choice(vocabulary=self._remove_vocabulary()),
             ))
             self.fields += Fields(schema.List(
                 __name__='added_values',

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -276,7 +276,6 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     @property
     def _vocabulary(self):
         """A SimpleVocabulary instance."""
-        return None
 
     def _should_keep_vocabulary_order(self):
         """Make order of stored values respect field vocabulary terms order?"""
@@ -285,7 +284,6 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     @property
     def _modified_attr_name(self):
         """The name of the attribute that will be modified on the object."""
-        return None
 
     @property
     def _removed_values_description(self):

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -288,6 +288,22 @@ class BaseARUOBatchActionForm(BaseBatchActionForm):
     # can the resulting set values be empty?
     required = False
 
+    @property
+    def description(self):
+        """ """
+        description = translate(super(BaseARUOBatchActionForm, self).description,
+                                context=self.request)
+        if self.required:
+            description += translate(
+                'field_can_not_be_empty_warning',
+                domain="collective.eeafaceted.batchactions",
+                context=self.request)
+        description += translate(
+            'aruo_action_replace_warning',
+            domain="collective.eeafaceted.batchactions",
+            context=self.request)
+        return description
+
     def _vocabulary(self):
         """A SimpleVocabulary instance or a vocabulary name, containing the values to add/set."""
         return None

--- a/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
+++ b/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-01 09:40+0000\n"
+"POT-Creation-Date: 2023-07-05 07:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,43 +17,43 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.eeafaceted.batchactions\n"
 
-#: ./browser/views.py:305
+#: ./browser/views.py:321
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:336
+#: ./browser/views.py:352
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:126
+#: ./browser/views.py:132
 msgid "Apply"
 msgstr ""
 
-#: ./browser/views.py:303
+#: ./browser/views.py:319
 msgid "Batch action choice"
 msgstr ""
 
-#: ./browser/views.py:51
+#: ./browser/views.py:53
 msgid "Batch action form"
 msgstr ""
 
-#: ./browser/views.py:402
+#: ./browser/views.py:491
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:271
+#: ./browser/views.py:397
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:158
+#: ./browser/views.py:164
 msgid "Batch state change"
 msgstr ""
 
-#: ./browser/views.py:195
+#: ./browser/views.py:201
 msgid "Comment"
 msgstr ""
 
-#: ./browser/views.py:211
+#: ./browser/views.py:217
 msgid "Delete elements"
 msgstr ""
 
@@ -61,43 +61,51 @@ msgstr ""
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr ""
 
-#: ./browser/views.py:191
+#: ./browser/views.py:197
 msgid "No common or available transition. Modify your selection."
 msgstr ""
 
-#: ./browser/views.py:196
+#: ./browser/views.py:202
 msgid "Optional comment to display in history"
 msgstr ""
 
-#: ./browser/views.py:308
+#: ./browser/views.py:324
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:306
+#: ./browser/views.py:322
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:329
+#: ./browser/views.py:345
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:307
+#: ./browser/views.py:323
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:434
+#: ./browser/views.py:523
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:426
+#: ./browser/views.py:515
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:337
+#: ./browser/views.py:298
+msgid "Select the values to add."
+msgstr ""
+
+#: ./browser/views.py:410
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:330
+#: ./browser/views.py:293
+msgid "Select the values to remove."
+msgstr ""
+
+#: ./browser/views.py:406
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -105,19 +113,19 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr ""
 
-#: ./browser/views.py:95
+#: ./browser/views.py:101
 msgid "This action will affect ${number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:232
+#: ./browser/views.py:238
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:188
+#: ./browser/views.py:194
 msgid "Transition"
 msgstr ""
 
-#: ./browser/views.py:247
+#: ./browser/views.py:253
 msgid "Update WF role mappings"
 msgstr ""
 
@@ -133,7 +141,7 @@ msgstr ""
 msgid "collective.eeafaceted.batchactions tests"
 msgstr ""
 
-#: ./browser/views.py:214
+#: ./browser/views.py:220
 msgid "delete-batch-action-but"
 msgstr ""
 

--- a/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
+++ b/src/collective/eeafaceted/batchactions/locales/collective.eeafaceted.batchactions.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-07-05 07:36+0000\n"
+"POT-Creation-Date: 2023-07-11 08:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.eeafaceted.batchactions\n"
 
-#: ./browser/views.py:321
+#: ./browser/views.py:329
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:352
+#: ./browser/views.py:360
 msgid "Added values"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: ./browser/views.py:319
+#: ./browser/views.py:327
 msgid "Batch action choice"
 msgstr ""
 
@@ -37,11 +37,11 @@ msgstr ""
 msgid "Batch action form"
 msgstr ""
 
-#: ./browser/views.py:491
+#: ./browser/views.py:504
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:397
+#: ./browser/views.py:411
 msgid "Batch labels change"
 msgstr ""
 
@@ -69,43 +69,43 @@ msgstr ""
 msgid "Optional comment to display in history"
 msgstr ""
 
-#: ./browser/views.py:324
+#: ./browser/views.py:332
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:322
+#: ./browser/views.py:330
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:345
+#: ./browser/views.py:353
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:323
+#: ./browser/views.py:331
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:523
+#: ./browser/views.py:536
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:515
+#: ./browser/views.py:528
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:298
+#: ./browser/views.py:281
 msgid "Select the values to add."
 msgstr ""
 
-#: ./browser/views.py:410
+#: ./browser/views.py:416
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:293
+#: ./browser/views.py:283
 msgid "Select the values to remove."
 msgstr ""
 
-#: ./browser/views.py:406
+#: ./browser/views.py:414
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -133,6 +133,10 @@ msgstr ""
 msgid "You can't change this field on selected items. Modify your selection."
 msgstr ""
 
+#. Default: "<p style='color: red;'>When using \"Replace\", resulting elements will be updated only if removed values were selected on original element.</p>"
+msgid "aruo_action_replace_warning"
+msgstr ""
+
 #: ./configure.zcml:32
 msgid "collective.eeafaceted.batchactions"
 msgstr ""
@@ -143,6 +147,10 @@ msgstr ""
 
 #: ./browser/views.py:220
 msgid "delete-batch-action-but"
+msgstr ""
+
+#. Default: "<p style='color: red;'>Warning, field can not be empty.</p>"
+msgid "field_can_not_be_empty_warning"
 msgstr ""
 
 #. Default: "Change labels"

--- a/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-07-05 07:36+0000\n"
+"POT-Creation-Date: 2023-07-11 08:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:321
+#: ./browser/views.py:329
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:352
+#: ./browser/views.py:360
 msgid "Added values"
 msgstr ""
 
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Apply"
 msgstr "Apply"
 
-#: ./browser/views.py:319
+#: ./browser/views.py:327
 msgid "Batch action choice"
 msgstr ""
 
@@ -34,11 +34,11 @@ msgstr ""
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:491
+#: ./browser/views.py:504
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:397
+#: ./browser/views.py:411
 msgid "Batch labels change"
 msgstr ""
 
@@ -66,43 +66,43 @@ msgstr "No common or available transition. Modify your selection."
 msgid "Optional comment to display in history"
 msgstr "Optional comment to display in history"
 
-#: ./browser/views.py:324
+#: ./browser/views.py:332
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:322
+#: ./browser/views.py:330
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:345
+#: ./browser/views.py:353
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:323
+#: ./browser/views.py:331
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:523
+#: ./browser/views.py:536
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:515
+#: ./browser/views.py:528
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:298
+#: ./browser/views.py:281
 msgid "Select the values to add."
 msgstr ""
 
-#: ./browser/views.py:410
+#: ./browser/views.py:416
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:293
+#: ./browser/views.py:283
 msgid "Select the values to remove."
 msgstr ""
 
-#: ./browser/views.py:406
+#: ./browser/views.py:414
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -130,6 +130,10 @@ msgstr "Update WF role mappings"
 msgid "You can't change this field on selected items. Modify your selection."
 msgstr ""
 
+#. Default: "<p style='color: red;'>When using \"Replace\", resulting elements will be updated only if removed values were selected on original element.</p>"
+msgid "aruo_action_replace_warning"
+msgstr ""
+
 #: ./configure.zcml:32
 msgid "collective.eeafaceted.batchactions"
 msgstr "collective.eeafaceted.batchactions"
@@ -142,6 +146,10 @@ msgstr "collective.eeafaceted.batchactions tests"
 #: ./browser/views.py:220
 msgid "delete-batch-action-but"
 msgstr "Delete"
+
+#. Default: "<p style='color: red;'>Warning, field can not be empty.</p>"
+msgid "field_can_not_be_empty_warning"
+msgstr ""
 
 #. Default: "Change labels"
 msgid "labels-batch-action-but"

--- a/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/en/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-01 09:40+0000\n"
+"POT-Creation-Date: 2023-07-05 07:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,43 +14,43 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:305
+#: ./browser/views.py:321
 msgid "Add items"
 msgstr ""
 
-#: ./browser/views.py:336
+#: ./browser/views.py:352
 msgid "Added values"
 msgstr ""
 
-#: ./browser/views.py:126
+#: ./browser/views.py:132
 msgid "Apply"
 msgstr "Apply"
 
-#: ./browser/views.py:303
+#: ./browser/views.py:319
 msgid "Batch action choice"
 msgstr ""
 
-#: ./browser/views.py:51
+#: ./browser/views.py:53
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:402
+#: ./browser/views.py:491
 msgid "Batch contact field change"
 msgstr ""
 
-#: ./browser/views.py:271
+#: ./browser/views.py:397
 msgid "Batch labels change"
 msgstr ""
 
-#: ./browser/views.py:158
+#: ./browser/views.py:164
 msgid "Batch state change"
 msgstr "Batch state change"
 
-#: ./browser/views.py:195
+#: ./browser/views.py:201
 msgid "Comment"
 msgstr "Comment"
 
-#: ./browser/views.py:211
+#: ./browser/views.py:217
 msgid "Delete elements"
 msgstr ""
 
@@ -58,43 +58,51 @@ msgstr ""
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:191
+#: ./browser/views.py:197
 msgid "No common or available transition. Modify your selection."
 msgstr "No common or available transition. Modify your selection."
 
-#: ./browser/views.py:196
+#: ./browser/views.py:202
 msgid "Optional comment to display in history"
 msgstr "Optional comment to display in history"
 
-#: ./browser/views.py:308
+#: ./browser/views.py:324
 msgid "Overwrite"
 msgstr ""
 
-#: ./browser/views.py:306
+#: ./browser/views.py:322
 msgid "Remove items"
 msgstr ""
 
-#: ./browser/views.py:329
+#: ./browser/views.py:345
 msgid "Removed values"
 msgstr ""
 
-#: ./browser/views.py:307
+#: ./browser/views.py:323
 msgid "Replace some items by others"
 msgstr ""
 
-#: ./browser/views.py:434
+#: ./browser/views.py:523
 msgid "Search and select the values to add."
 msgstr ""
 
-#: ./browser/views.py:426
+#: ./browser/views.py:515
 msgid "Search and select the values to remove, if necessary."
 msgstr ""
 
-#: ./browser/views.py:337
+#: ./browser/views.py:298
+msgid "Select the values to add."
+msgstr ""
+
+#: ./browser/views.py:410
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr ""
 
-#: ./browser/views.py:330
+#: ./browser/views.py:293
+msgid "Select the values to remove."
+msgstr ""
+
+#: ./browser/views.py:406
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr ""
 
@@ -102,19 +110,19 @@ msgstr ""
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:95
+#: ./browser/views.py:101
 msgid "This action will affect ${number} element(s)."
 msgstr "This action will affect ${number} element(s)."
 
-#: ./browser/views.py:232
+#: ./browser/views.py:238
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr ""
 
-#: ./browser/views.py:188
+#: ./browser/views.py:194
 msgid "Transition"
 msgstr "Transition"
 
-#: ./browser/views.py:247
+#: ./browser/views.py:253
 msgid "Update WF role mappings"
 msgstr "Update WF role mappings"
 
@@ -131,7 +139,7 @@ msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
 
 #. Default: "Delete"
-#: ./browser/views.py:214
+#: ./browser/views.py:220
 msgid "delete-batch-action-but"
 msgstr "Delete"
 

--- a/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-01 09:40+0000\n"
+"POT-Creation-Date: 2023-07-05 07:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,43 +14,43 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:305
+#: ./browser/views.py:321
 msgid "Add items"
 msgstr "Ajouter des éléments"
 
-#: ./browser/views.py:336
+#: ./browser/views.py:352
 msgid "Added values"
 msgstr "Éléments à ajouter / fixés"
 
-#: ./browser/views.py:126
+#: ./browser/views.py:132
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ./browser/views.py:303
+#: ./browser/views.py:319
 msgid "Batch action choice"
 msgstr "Choix de l'action à effectuer"
 
-#: ./browser/views.py:51
+#: ./browser/views.py:53
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:402
+#: ./browser/views.py:491
 msgid "Batch contact field change"
 msgstr "Changement de contact par lot"
 
-#: ./browser/views.py:271
+#: ./browser/views.py:397
 msgid "Batch labels change"
 msgstr "Changer les étiquettes par lot"
 
-#: ./browser/views.py:158
+#: ./browser/views.py:164
 msgid "Batch state change"
 msgstr "Changer l'état par lot"
 
-#: ./browser/views.py:195
+#: ./browser/views.py:201
 msgid "Comment"
 msgstr "Commentaire"
 
-#: ./browser/views.py:211
+#: ./browser/views.py:217
 msgid "Delete elements"
 msgstr "Supprimer les éléments par lot"
 
@@ -58,43 +58,51 @@ msgstr "Supprimer les éléments par lot"
 msgid "Extension profile for collective.eeafaceted.batchactions."
 msgstr "Extension profile for collective.eeafaceted.batchactions."
 
-#: ./browser/views.py:191
+#: ./browser/views.py:197
 msgid "No common or available transition. Modify your selection."
 msgstr "<span style='color: red;'>Aucune transition commune ou valide. Recommencez en modifiant votre sélection.</span>"
 
-#: ./browser/views.py:196
+#: ./browser/views.py:202
 msgid "Optional comment to display in history"
 msgstr "Commentaire optionnel qui sera affiché dans l'historique."
 
-#: ./browser/views.py:308
+#: ./browser/views.py:324
 msgid "Overwrite"
 msgstr "Écraser le contenu avec les éléments choisis"
 
-#: ./browser/views.py:306
+#: ./browser/views.py:322
 msgid "Remove items"
 msgstr "Retirer des éléments"
 
-#: ./browser/views.py:329
+#: ./browser/views.py:345
 msgid "Removed values"
 msgstr "Éléments à retirer"
 
-#: ./browser/views.py:307
+#: ./browser/views.py:323
 msgid "Replace some items by others"
 msgstr "Remplacer des éléments par d'autres"
 
-#: ./browser/views.py:434
+#: ./browser/views.py:523
 msgid "Search and select the values to add."
 msgstr "Chercher et sélectionner des contacts à ajouter."
 
-#: ./browser/views.py:426
+#: ./browser/views.py:515
 msgid "Search and select the values to remove, if necessary."
 msgstr "Chercher et sélectionner des contacts à retirer, si nécessaire."
 
-#: ./browser/views.py:337
+#: ./browser/views.py:298
+msgid "Select the values to add."
+msgstr "Sélectionner les éléments à ajouter."
+
+#: ./browser/views.py:410
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à ajouter. Une étiquette utilisateur est indiquée par (*)."
 
-#: ./browser/views.py:330
+#: ./browser/views.py:293
+msgid "Select the values to remove."
+msgstr "Sélectionner les éléments à retirer."
+
+#: ./browser/views.py:406
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est indiquée par (*)."
 
@@ -102,19 +110,19 @@ msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est 
 msgid "Steps to ease tests of collective.eeafaceted.batchactions"
 msgstr "Steps to ease tests of collective.eeafaceted.batchactions"
 
-#: ./browser/views.py:95
+#: ./browser/views.py:101
 msgid "This action will affect ${number} element(s)."
 msgstr "Cette action concerne <b>${number} élément(s)</b>."
 
-#: ./browser/views.py:232
+#: ./browser/views.py:238
 msgid "This action will only affect ${deletable_number} element(s), indeed you do not have the permission to delete ${not_deletable_number} element(s)."
 msgstr "Cette action ne sera appliquée que sur <b>${deletable_number} élément(s) sélectionné(s)</b> car <span style='color: red;'>vous n'avez pas la permission de supprimer les autres ${not_deletable_number} élément(s).</span>"
 
-#: ./browser/views.py:188
+#: ./browser/views.py:194
 msgid "Transition"
 msgstr "Transition"
 
-#: ./browser/views.py:247
+#: ./browser/views.py:253
 msgid "Update WF role mappings"
 msgstr "Mettre à jour les rôles/permissions (WF)"
 
@@ -131,7 +139,7 @@ msgid "collective.eeafaceted.batchactions tests"
 msgstr "collective.eeafaceted.batchactions tests"
 
 #. Default: "Delete"
-#: ./browser/views.py:214
+#: ./browser/views.py:220
 msgid "delete-batch-action-but"
 msgstr "Supprimer"
 

--- a/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
+++ b/src/collective/eeafaceted/batchactions/locales/fr/LC_MESSAGES/collective.eeafaceted.batchactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-07-05 07:36+0000\n"
+"POT-Creation-Date: 2023-07-11 08:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:321
+#: ./browser/views.py:329
 msgid "Add items"
 msgstr "Ajouter des éléments"
 
-#: ./browser/views.py:352
+#: ./browser/views.py:360
 msgid "Added values"
 msgstr "Éléments à ajouter / fixés"
 
@@ -26,7 +26,7 @@ msgstr "Éléments à ajouter / fixés"
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ./browser/views.py:319
+#: ./browser/views.py:327
 msgid "Batch action choice"
 msgstr "Choix de l'action à effectuer"
 
@@ -34,11 +34,11 @@ msgstr "Choix de l'action à effectuer"
 msgid "Batch action form"
 msgstr "Batch action form"
 
-#: ./browser/views.py:491
+#: ./browser/views.py:504
 msgid "Batch contact field change"
 msgstr "Changement de contact par lot"
 
-#: ./browser/views.py:397
+#: ./browser/views.py:411
 msgid "Batch labels change"
 msgstr "Changer les étiquettes par lot"
 
@@ -66,43 +66,43 @@ msgstr "<span style='color: red;'>Aucune transition commune ou valide. Recommenc
 msgid "Optional comment to display in history"
 msgstr "Commentaire optionnel qui sera affiché dans l'historique."
 
-#: ./browser/views.py:324
+#: ./browser/views.py:332
 msgid "Overwrite"
 msgstr "Écraser le contenu avec les éléments choisis"
 
-#: ./browser/views.py:322
+#: ./browser/views.py:330
 msgid "Remove items"
 msgstr "Retirer des éléments"
 
-#: ./browser/views.py:345
+#: ./browser/views.py:353
 msgid "Removed values"
 msgstr "Éléments à retirer"
 
-#: ./browser/views.py:323
+#: ./browser/views.py:331
 msgid "Replace some items by others"
 msgstr "Remplacer des éléments par d'autres"
 
-#: ./browser/views.py:523
+#: ./browser/views.py:536
 msgid "Search and select the values to add."
 msgstr "Chercher et sélectionner des contacts à ajouter."
 
-#: ./browser/views.py:515
+#: ./browser/views.py:528
 msgid "Search and select the values to remove, if necessary."
 msgstr "Chercher et sélectionner des contacts à retirer, si nécessaire."
 
-#: ./browser/views.py:298
+#: ./browser/views.py:281
 msgid "Select the values to add."
 msgstr "Sélectionner les éléments à ajouter."
 
-#: ./browser/views.py:410
+#: ./browser/views.py:416
 msgid "Select the values to add. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à ajouter. Une étiquette utilisateur est indiquée par (*)."
 
-#: ./browser/views.py:293
+#: ./browser/views.py:283
 msgid "Select the values to remove."
 msgstr "Sélectionner les éléments à retirer."
 
-#: ./browser/views.py:406
+#: ./browser/views.py:414
 msgid "Select the values to remove. A personal label is represented by (*)."
 msgstr "Sélectionner les éléments à retirer. Une étiquette utilisateur est indiquée par (*)."
 
@@ -130,6 +130,10 @@ msgstr "Mettre à jour les rôles/permissions (WF)"
 msgid "You can't change this field on selected items. Modify your selection."
 msgstr "Vous ne pouvez pas modifier de manière commune ce champ sur les éléments sélectionnés. Modifiez votre sélection."
 
+#. Default: "<p style='color: red;'>When using \"Replace\", resulting elements will be updated only if removed values were selected on original element.</p>"
+msgid "aruo_action_replace_warning"
+msgstr "<p style='color: red;'>Lors de l'utilisation de l'action \"Remplacer des éléments par d'autres\", l'action ne sera appliquée que si les \"Éléments à retirer\" sont tous présents à l'origine.</p>"
+
 #: ./configure.zcml:32
 msgid "collective.eeafaceted.batchactions"
 msgstr "collective.eeafaceted.batchactions"
@@ -142,6 +146,10 @@ msgstr "collective.eeafaceted.batchactions tests"
 #: ./browser/views.py:220
 msgid "delete-batch-action-but"
 msgstr "Supprimer"
+
+#. Default: "<p style='color: red;'>Warning, field can not be empty.</p>"
+msgid "field_can_not_be_empty_warning"
+msgstr "<p style='color: red;'>Attention le champ est requis et une action qui enleverait la dernière valeur sélectionnée ne sera pas appliquée.</p>"
 
 #. Default: "Change labels"
 msgid "labels-batch-action-but"

--- a/src/collective/eeafaceted/batchactions/locales/manual.pot
+++ b/src/collective/eeafaceted/batchactions/locales/manual.pot
@@ -25,3 +25,11 @@ msgstr ""
 #. Default: "Update WF role mappings"
 msgid "update-wf-role-mappings-batch-action-but"
 msgstr ""
+
+#. Default: "<p style='color: red;'>Warning, field can not be empty.</p>"
+msgid "field_can_not_be_empty_warning"
+msgstr ""
+
+#. Default: "<p style='color: red;'>When using \"Replace\", resulting elements will be updated only if removed values were selected on original element.</p>"
+msgid "aruo_action_replace_warning"
+msgstr ""

--- a/src/collective/eeafaceted/batchactions/testing.zcml
+++ b/src/collective/eeafaceted/batchactions/testing.zcml
@@ -23,6 +23,12 @@
       permission="zope2.View" />
 
   <browser:page
+      for="collective.eeafaceted.batchactions.tests.interfaces.IBatchActionsMarker"
+      name="testing-aruo-batch-action"
+      class=".tests.views.TestingARUOBatchActionForm"
+      permission="zope2.View" />
+
+  <browser:page
       for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
       name="labels-batch-action"
       class=".browser.views.LabelsBatchActionForm"

--- a/src/collective/eeafaceted/batchactions/testing.zcml
+++ b/src/collective/eeafaceted/batchactions/testing.zcml
@@ -40,10 +40,4 @@
       class=".tests.views.ContactBatchActionForm"
       permission="zope2.View" />
 
-  <browser:page
-      for="collective.eeafaceted.batchactions.interfaces.IBatchActionsMarker"
-      name="delete-batch-action"
-      class=".browser.views.DeleteBatchActionForm"
-      permission="zope2.View" />
-
 </configure>

--- a/src/collective/eeafaceted/batchactions/tests/base.py
+++ b/src/collective/eeafaceted/batchactions/tests/base.py
@@ -30,3 +30,4 @@ class BaseTestCase(unittest.TestCase):
         eea_folder.restrictedTraverse('@@faceted_subtyper').enable()
         IFacetedLayout(eea_folder).update_layout('faceted-table-items')
         self.eea_folder = eea_folder
+        self.maxDiff = None

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -241,3 +241,20 @@ class TestActions(BaseTestCase):
         self.assertFalse(_checkPermission(View, self.doc1))
         self.assertFalse(_checkPermission(View, self.doc2))
         self.assertEqual(len(catalog(UID=[self.doc1.UID(), self.doc2.UID()])), 0)
+
+    def test_aruo_action(self):
+        """Update 'custom_portal_type' attribute."""
+        self.doc1.custom_portal_types = ['testtype']
+        doc_uids = self.doc1.UID()
+        self.request.form['form.widgets.uids'] = doc_uids
+        form = self.eea_folder.restrictedTraverse('testing-aruo-batch-action')
+        form.update()
+        # "testtype" portal_type is at the end of portal_types,
+        # if we add "Document" portal_type, order is respected
+        self.request['form.widgets.added_values'] = ['Document']
+        self.request['form.widgets.action_choice'] = 'add'
+        form.handleApply(form, None)
+        self.assertEqual(self.doc1.custom_portal_types, ['Document', 'testtype'])
+        # "position" portal_type will be added between existing values
+        self.request['form.widgets.added_values'] = ['position']
+        self.assertEqual(self.doc1.custom_portal_types, ['Document', 'position', 'testtype'])

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -292,3 +292,13 @@ class TestActions(BaseTestCase):
         self.request['form.widgets.removed_values'] = ['Document']
         form.handleApply(form, None)
         self.assertEqual(self.doc1.custom_portal_types, ['Document'])
+        # replace, only replaced if exists
+        self.request['form.widgets.action_choice'] = 'replace'
+        self.request['form.widgets.added_values'] = ['position']
+        self.request['form.widgets.removed_values'] = ['testtype']
+        form.handleApply(form, None)
+        self.assertEqual(self.doc1.custom_portal_types, ['Document'])
+        # now replace a really selected value
+        self.request['form.widgets.removed_values'] = ['Document']
+        form.handleApply(form, None)
+        self.assertEqual(self.doc1.custom_portal_types, ['position'])

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -243,7 +243,7 @@ class TestActions(BaseTestCase):
         self.assertFalse(_checkPermission(View, self.doc2))
         self.assertEqual(len(catalog(UID=[self.doc1.UID(), self.doc2.UID()])), 0)
 
-    def test_aruo_action(self):
+    def do_test_aruo_action(self, vocab_name=True):
         """Update 'custom_portal_type' attribute."""
         addOrUpdateIndexes(
             self.portal,
@@ -257,6 +257,8 @@ class TestActions(BaseTestCase):
         doc_uids = self.doc1.UID()
         self.request.form['form.widgets.uids'] = doc_uids
         form = self.eea_folder.restrictedTraverse('testing-aruo-batch-action')
+        if vocab_name:
+            form._vocabulary = lambda: 'plone.app.vocabularies.PortalTypes'
         form.update()
         # "testtype" portal_type is at the end of portal_types,
         # if we add "Document" portal_type, order is respected
@@ -302,3 +304,11 @@ class TestActions(BaseTestCase):
         self.request['form.widgets.removed_values'] = ['Document']
         form.handleApply(form, None)
         self.assertEqual(self.doc1.custom_portal_types, ['position'])
+
+    def test_aruo_action_with_true_vocab(self):
+        """Update 'custom_portal_type' attribute."""
+        self.do_test_aruo_action(vocab_name=False)
+
+    def test_aruo_action_with_vocab_name(self):
+        """Update 'custom_portal_type' attribute."""
+        self.do_test_aruo_action(vocab_name=True)

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -283,3 +283,12 @@ class TestActions(BaseTestCase):
         self.assertTrue(catalog(custom_portal_types='testtype'))
         self.assertTrue(catalog(custom_portal_types='Document'))
         self.assertFalse(catalog(custom_portal_types='position'))
+        # field is required, it is not possible to remove every values
+        # remove 'testtype'
+        self.request['form.widgets.removed_values'] = ['testtype']
+        form.handleApply(form, None)
+        self.assertEqual(self.doc1.custom_portal_types, ['Document'])
+        # trying to remove 'Document' will do nothing
+        self.request['form.widgets.removed_values'] = ['Document']
+        form.handleApply(form, None)
+        self.assertEqual(self.doc1.custom_portal_types, ['Document'])

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -159,6 +159,7 @@ class TestActions(BaseTestCase):
 
     def test_delete_action(self):
         """Delete batch action."""
+        login(self.portal.aq_parent, "admin")
         # make eea_folder not deletable
         self.eea_folder.manage_permission(DeleteObjects, [])
         self.assertFalse(_checkPermission(DeleteObjects, self.eea_folder))

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -247,7 +247,7 @@ class TestActions(BaseTestCase):
         """Update 'custom_portal_type' attribute."""
         addOrUpdateIndexes(
             self.portal,
-            indexInfos={'custom_portal_types': ('KeywordIndex', {}),})
+            indexInfos={'custom_portal_types': ('KeywordIndex', {}), })
         catalog = self.portal.portal_catalog
         self.doc1.custom_portal_types = ['testtype']
         self.doc1.reindexObject()

--- a/src/collective/eeafaceted/batchactions/tests/test_forms.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_forms.py
@@ -251,10 +251,11 @@ class TestActions(BaseTestCase):
         form.update()
         # "testtype" portal_type is at the end of portal_types,
         # if we add "Document" portal_type, order is respected
-        self.request['form.widgets.added_values'] = ['Document']
         self.request['form.widgets.action_choice'] = 'add'
+        self.request['form.widgets.added_values'] = ['Document']
         form.handleApply(form, None)
         self.assertEqual(self.doc1.custom_portal_types, ['Document', 'testtype'])
         # "position" portal_type will be added between existing values
         self.request['form.widgets.added_values'] = ['position']
+        form.handleApply(form, None)
         self.assertEqual(self.doc1.custom_portal_types, ['Document', 'position', 'testtype'])

--- a/src/collective/eeafaceted/batchactions/tests/test_labels_form.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_labels_form.py
@@ -84,18 +84,31 @@ class TestLabels(BaseTestCase):
         self.assertTupleEqual(active_labels(self.lab_doc1), ([], []))
 
         # test replace action
+        # in case of a 'replace', values are replaced only if it was actually selected on the element
+        # so here as nothing selected anymore, nothing changed
         form.widgets.extract = lambda *a, **kw: ({'action_choice': 'replace',
                                                   'removed_values': ['pers1:', 'glob1'],
                                                   'added_values': ['pers2:', 'pers3:', 'glob2', 'glob3']}, [])
         form.handleApply(form, None)
-        act_lab = active_labels(self.lab_doc1)
-        self.assertSetEqual(set(act_lab[0]), set(['pers2', 'pers3']))
-        self.assertSetEqual(set(act_lab[1]), set(['glob2', 'glob3']))
+        self.assertTupleEqual(active_labels(self.lab_doc1), ([], []))
+
+        # now add a value and replace it
+        # add
+        form.widgets.extract = lambda *a, **kw: ({'action_choice': 'add',
+                                                  'added_values': ['pers1:', 'glob1']}, [])
+        form.handleApply(form, None)
+        self.assertTupleEqual(active_labels(self.lab_doc1), (['pers1'], ['glob1']))
+        # replace
+        form.widgets.extract = lambda *a, **kw: ({'action_choice': 'replace',
+                                                  'removed_values': ['pers1:', 'glob1'],
+                                                  'added_values': ['pers2:', 'glob2']}, [])
+        form.handleApply(form, None)
+        self.assertTupleEqual(active_labels(self.lab_doc1), (['pers2'], ['glob2']))
 
         # test overwrite action
         form.widgets.extract = lambda *a, **kw: ({'action_choice': 'overwrite',
-                                                  'added_values': ['pers1:', 'glob1']}, [])
+                                                  'added_values': ['pers1:', 'glob3']}, [])
         form.handleApply(form, None)
         act_lab = active_labels(self.lab_doc1)
         self.assertSetEqual(set(act_lab[0]), set(['pers1']))
-        self.assertSetEqual(set(act_lab[1]), set(['glob1']))
+        self.assertSetEqual(set(act_lab[1]), set(['glob3']))

--- a/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
@@ -88,9 +88,9 @@ class TestViewlets(BaseTestCase):
         # as zope admin
         login(self.portal.aq_parent, "admin")
         self.assertEqual(
-            [dic['name'] for dic in viewlet.get_batch_actions()],
-            ['delete-batch-action', 'transition-batch-action', 'labels-batch-action', 'contact-batch-action',
-             'testing-aruo-batch-action', 'update-wf-role-mappings-batch-action'])
+            sorted([dic['name'] for dic in viewlet.get_batch_actions()]),
+            ['contact-batch-action', 'delete-batch-action', 'labels-batch-action', 'testing-aruo-batch-action',
+             'transition-batch-action', 'update-wf-role-mappings-batch-action'])
 
     def test_get_batch_actions_available(self):
         """A method 'available' is evaluated on the action view to check if it is available on context."""

--- a/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
@@ -5,6 +5,7 @@ from collective.eeafaceted.batchactions.interfaces import IBatchActionsMarker
 from collective.eeafaceted.batchactions.tests.base import BaseTestCase
 from collective.eeafaceted.batchactions.tests.interfaces import IBatchActionsSpecificMarker
 from plone import api
+from plone.app.testing import login
 from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
@@ -76,8 +77,7 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(self.eea_folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
-             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
              {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])
@@ -85,6 +85,12 @@ class TestViewlets(BaseTestCase):
         for action in viewlet.get_batch_actions():
             form = self.eea_folder.restrictedTraverse(action['name'])
             self.assertEqual(form.__name__, action['name'])
+        # as zope admin
+        login(self.portal.aq_parent, "admin")
+        self.assertEqual(
+            [dic['name'] for dic in viewlet.get_batch_actions()],
+            ['delete-batch-action', 'transition-batch-action', 'labels-batch-action', 'contact-batch-action',
+             'testing-aruo-batch-action', 'update-wf-role-mappings-batch-action'])
 
     def test_get_batch_actions_available(self):
         """A method 'available' is evaluated on the action view to check if it is available on context."""
@@ -112,18 +118,16 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
-             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
-             {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
-             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
-             {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])
+            [{'button_with_icon': False, 'name': 'transition-batch-action', 'weight': 10, 'overlay': True},
+             {'button_with_icon': False, 'name': 'labels-batch-action', 'weight': 20, 'overlay': True},
+             {'button_with_icon': False, 'name': 'contact-batch-action', 'weight': 30, 'overlay': True},
+             {'button_with_icon': False, 'name': 'testing-aruo-batch-action', 'weight': 100, 'overlay': True}])
 
         # mark with IBatchActionsSpecificMarker
         alsoProvides(folder, IBatchActionsSpecificMarker)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
-             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
              {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100},
@@ -137,8 +141,7 @@ class TestViewlets(BaseTestCase):
         viewlet = self._get_viewlet(self.eea_folder)
         self.assertEqual(
             viewlet.get_batch_actions(),
-            [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
-             {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
+            [{'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
              {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])

--- a/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
+++ b/src/collective/eeafaceted/batchactions/tests/test_viewlets.py
@@ -79,7 +79,8 @@ class TestViewlets(BaseTestCase):
             [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
              {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
-             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])
+             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
+             {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])
         # returned action names are traversable to get the form
         for action in viewlet.get_batch_actions():
             form = self.eea_folder.restrictedTraverse(action['name'])
@@ -114,7 +115,8 @@ class TestViewlets(BaseTestCase):
             [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
              {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
-             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])
+             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
+             {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])
 
         # mark with IBatchActionsSpecificMarker
         alsoProvides(folder, IBatchActionsSpecificMarker)
@@ -124,6 +126,7 @@ class TestViewlets(BaseTestCase):
              {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
              {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
+             {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100},
              {'name': 'testing-batch-action', 'button_with_icon': True, 'overlay': False, 'weight': 100}])
         # returned action names are traversable to get the form
         for action in viewlet.get_batch_actions():
@@ -137,4 +140,5 @@ class TestViewlets(BaseTestCase):
             [{'button_with_icon': True, 'name': 'delete-batch-action', 'weight': 5, 'overlay': True},
              {'name': 'transition-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 10},
              {'name': 'labels-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 20},
-             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30}])
+             {'name': 'contact-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 30},
+             {'name': 'testing-aruo-batch-action', 'button_with_icon': False, 'overlay': True, 'weight': 100}])

--- a/src/collective/eeafaceted/batchactions/tests/views.py
+++ b/src/collective/eeafaceted/batchactions/tests/views.py
@@ -1,7 +1,11 @@
+# -*- coding: utf-8 -*-
+
 from collective.contact.widget.schema import ContactChoice
 from collective.contact.widget.source import ContactSourceBinder
 from collective.eeafaceted.batchactions.browser.views import BaseBatchActionForm
+from collective.eeafaceted.batchactions.browser.views import BaseARUOBatchActionForm
 from collective.eeafaceted.batchactions.browser.views import ContactBaseBatchActionForm
+from imio.helpers.content import get_vocab
 
 
 class TestingBatchActionForm(BaseBatchActionForm):
@@ -24,3 +28,26 @@ class ContactBatchActionForm(ContactBaseBatchActionForm):
     available_permission = 'Manage portal'
     attribute = 'related_organizations'
     field_value_type = ContactChoice(source=ContactSourceBinder(portal_type="organization"))
+
+
+class TestingARUOBatchActionForm(BaseARUOBatchActionForm):
+
+    @property
+    def _vocabulary(self):
+        return get_vocab(self.context, 'plone.app.vocabularies.PortalTypes')
+
+    @property
+    def _modified_attr_name(self):
+        return 'custom_portal_types'
+
+    @property
+    def _indexes(self):
+        # call super() for coverage
+        super(TestingARUOBatchActionForm, self)._indexes
+        return ['portal_type']
+
+    @property
+    def _should_call_modified_event(self):
+        # call super() for coverage
+        super(TestingARUOBatchActionForm, self)._should_call_modified_event
+        return True

--- a/src/collective/eeafaceted/batchactions/tests/views.py
+++ b/src/collective/eeafaceted/batchactions/tests/views.py
@@ -35,7 +35,7 @@ class TestingARUOBatchActionForm(BaseARUOBatchActionForm):
     modified_attr_name = 'custom_portal_types'
     indexes = 'custom_portal_types'
     call_modified_event = True
+    required = True
 
-    @property
     def _vocabulary(self):
         return get_vocab(self.context, 'plone.app.vocabularies.PortalTypes')

--- a/src/collective/eeafaceted/batchactions/tests/views.py
+++ b/src/collective/eeafaceted/batchactions/tests/views.py
@@ -32,22 +32,10 @@ class ContactBatchActionForm(ContactBaseBatchActionForm):
 
 class TestingARUOBatchActionForm(BaseARUOBatchActionForm):
 
+    modified_attr_name = 'custom_portal_types'
+    indexes = 'custom_portal_types'
+    call_modified_event = True
+
     @property
     def _vocabulary(self):
         return get_vocab(self.context, 'plone.app.vocabularies.PortalTypes')
-
-    @property
-    def _modified_attr_name(self):
-        return 'custom_portal_types'
-
-    @property
-    def _indexes(self):
-        # call super() for coverage
-        super(TestingARUOBatchActionForm, self)._indexes
-        return ['portal_type']
-
-    @property
-    def _should_call_modified_event(self):
-        # call super() for coverage
-        super(TestingARUOBatchActionForm, self)._should_call_modified_event
-        return True

--- a/src/collective/eeafaceted/batchactions/tests/views.py
+++ b/src/collective/eeafaceted/batchactions/tests/views.py
@@ -2,8 +2,8 @@
 
 from collective.contact.widget.schema import ContactChoice
 from collective.contact.widget.source import ContactSourceBinder
-from collective.eeafaceted.batchactions.browser.views import BaseBatchActionForm
 from collective.eeafaceted.batchactions.browser.views import BaseARUOBatchActionForm
+from collective.eeafaceted.batchactions.browser.views import BaseBatchActionForm
 from collective.eeafaceted.batchactions.browser.views import ContactBaseBatchActionForm
 from imio.helpers.content import get_vocab
 


### PR DESCRIPTION
A class factorizing the action that `add/remove/update/overwrite` values on an attribute of an object (originally used for the `LabelsBatchActionForm`) so it is easier to reuse for other similar actions. `LabelsBatchActionForm` is now based on that `BaseARUOBatchActionForm`.

See #MPMBRWP-15