### PR TITLE
Added `PMLabelsBatchActionForm._filter_labels_vocabulary` to be able to filter selectable labels vocabulary.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
           pip3 install -U "coveralls>=3.0.0" coverage==5.3.1 --no-cache-dir
       - name: Publish to Coveralls
         env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          coveralls --service=github
+          coveralls --service=github-actions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
       - name: test coverage
         run: |
           coverage run bin/test
+          coverage report
       - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 1.16.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Added `PMLabelsBatchActionForm._filter_labels_vocabulary` to be able to filter
+  selectable labels vocabulary.
+  [gbastien]
 
 1.16.4 (2025-06-25)
 -------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-4.x.cfg
-    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-4.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     buildout.d/dev.cfg

--- a/buildout.d/base.cfg
+++ b/buildout.d/base.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     versions.cfg
 
 parts += createcoverage

--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -10,6 +10,7 @@ PyYAML = 3.10
 argh = 0.24.1
 aws.zope2zcmldoc = 1.1.0
 backports.functools-lru-cache = 1.6.4
+collective.excelexport = 1.8.2
 collective.profiler = 0.3
 createcoverage = 1.2
 coverage = 3.7.1
@@ -76,4 +77,3 @@ pep517 = 0.8.2
 z3c.unconfigure = 1.1
 
 pkginfo = 1.8.3
-

--- a/src/collective/eeafaceted/batchactions/browser/views.py
+++ b/src/collective/eeafaceted/batchactions/browser/views.py
@@ -450,25 +450,31 @@ class LabelsBatchActionForm(BaseARUOBatchActionForm):
     def get_labeljar_context(self):
         return self.context
 
+    def _filter_labels_vocabulary(self, jar):
+        return jar.list()
+
     def get_labels_vocabulary(self):
         terms, p_labels, g_labels = [], [], []
         context = self.get_labeljar_context()
         try:
-            adapted = ILabelJar(context)
+            jar = ILabelJar(context)
         except Exception:
             return SimpleVocabulary(terms), [], []
         self.can_change_labels = self._can_change_labels()
-        for label in adapted.list():
+        for label in self._filter_labels_vocabulary(jar):
             if label['by_user']:
                 p_labels.append(label['label_id'])
-                terms.append(SimpleVocabulary.createTerm('%s:' % label['label_id'],
-                                                         label['label_id'],
-                                                         u'{} (*)'.format(safe_unicode(label['title']))))
+                terms.append(SimpleVocabulary.createTerm(
+                    '%s:' % label['label_id'],
+                    label['label_id'],
+                    u'{} (*)'.format(safe_unicode(label['title']))))
             else:
                 g_labels.append(label['label_id'])
                 if self.can_change_labels:
-                    terms.append(SimpleVocabulary.createTerm(label['label_id'], label['label_id'],
-                                                             safe_unicode(label['title'])))
+                    terms.append(SimpleVocabulary.createTerm(
+                        label['label_id'],
+                        label['label_id'],
+                        safe_unicode(label['title'])))
         return SimpleVocabulary(terms), set(p_labels), g_labels
 
     def _apply(self, **data):


### PR DESCRIPTION
See #PM-4215
Salut @sgeulette 

ne change rien tel quel, permet juste de filtrer les termes du vocabulaire dans une fonction private sans devoir surcharger entièrement get_labels_vocabulary

C'est lié au dev qu'on fait dans PM, une config d'étiquettes qui dit qui peut voir, qui peut éditer, ...

Ce sera intéressant à un moment de le sortir de PM pour que ce soit aussi utilisable dans Docs si vous en avez besoin à un moment mais là c'était trop short et çà dépend de trop de choses inclues dans PM...

Merci pour le review!

Gauthier